### PR TITLE
Add GitHub Actions workflow for team article creation

### DIFF
--- a/.github/workflows/team-article-creation.yml
+++ b/.github/workflows/team-article-creation.yml
@@ -1,0 +1,35 @@
+name: Team Article Creation Pipeline
+
+on:
+  schedule:
+    # run once a day at 2 AM UTC
+    - cron: '0 2 * * *'  # Runs daily at 2 AM UTC
+  workflow_dispatch:  # Allows manual triggering
+
+jobs:
+  create-articles:
+    runs-on: ubuntu-latest
+    
+    env:
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_KEY: ${{ secrets.SUPABASE_KEY }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+      Custom_Search_API_KEY: ${{ secrets.CUSTOM_SEARCH_API_KEY }}
+      GOOGLE_CUSTOM_SEARCH_ID: ${{ secrets.GOOGLE_CUSTOM_SEARCH_ID }}
+    
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+    
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+    
+    - name: Run team article creation pipeline
+      run: python teamPipeline.py


### PR DESCRIPTION
This commit introduces a new workflow that automates the creation of team articles. The workflow is scheduled to run daily at 2 AM UTC and can also be triggered manually. It sets up the necessary environment variables and installs dependencies before executing the article creation script. This enhancement aims to streamline the article generation process and ensure timely updates.